### PR TITLE
League history updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,20 +230,20 @@
                     <td>2025</td>
                     <td>Lucas Yoder</td>
                     <td>Stuart Wyse</td>
-                    <td>Tyson Dietrich</td>
+                    <td>Tyson Dietrich (2/2)</td>
                     <td>Jake Elting</td>
                   </tr>
                   <tr>
                     <td>2024</td>
-                    <td>Nick Duffield</td>
+                    <td>Nick Duffield (2/3)</td>
                     <td>Dylan Bentley</td>
-                    <td>Nick Duffield</td>
+                    <td>Nick Duffield (3/3)</td>
                     <td>Seth Yoder</td>
                   </tr>
                   <tr>
                     <td>2023</td>
-                    <td>Tyson Dietrich</td>
-                    <td>Nick Duffield</td>
+                    <td>Tyson Dietrich (1/2)</td>
+                    <td>Nick Duffield (1/3)</td>
                     <td>Andy Brink</td>
                     <td>Josh Wyse</td>
                   </tr>

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
         <div class="block">
           <div class="column">
             <div class="banner_text">
-              <h3 class="header header--banner">Majors Best Ball</h3>
+              <h3 class="header header--banner">Majors Best Ball ⛳️</h3>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -201,6 +201,55 @@
 
         <div class="tab-pane fade" id="league-history" role="tabpanel" aria-labelledby="league-history-tab">
           <div class="mt-4">
+            <h3>Previous Season Winners</h3>
+            <ul class="list-group mb-4">
+              <li class="list-group-item">
+                <span>2025</span> - <span>🥇 Seth Yoder</span> <span class="ml-3">🥈 Stuart Wyse</span> <span class="ml-3">🥉 Mark Wohlever</span>
+              </li>
+              <li class="list-group-item">
+                <span>2024</span> - <span>🥇 Seth Yoder</span> <span class="ml-3">🥈 Nick Duffield</span> <span class="ml-3">🥉 Andy Brink</span>
+              </li>
+              <li class="list-group-item">
+                <span>2023</span> - <span>🥇 Josh Wyse</span> <span class="ml-3">🥈 Lucas Yoder</span> <span class="ml-3">🥉 Tyson Dietrich</span>
+              </li>
+            </ul>
+            <h3>Major Championship Winners</h3>
+            <div class="table-responsive mb-4">
+              <table class="table table-bordered text-center">
+                <thead class="thead-light">
+                  <tr>
+                    <th>Year</th>
+                    <th>Masters</th>
+                    <th>PGA Championship</th>
+                    <th>US Open</th>
+                    <th>The Open Championship</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>2025</td>
+                    <td>Lucas Yoder</td>
+                    <td>Stuart Wyse</td>
+                    <td>Tyson Dietrich</td>
+                    <td>Jake Elting</td>
+                  </tr>
+                  <tr>
+                    <td>2024</td>
+                    <td>Nick Duffield</td>
+                    <td>Dylan Bentley</td>
+                    <td>Nick Duffield</td>
+                    <td>Seth Yoder</td>
+                  </tr>
+                  <tr>
+                    <td>2023</td>
+                    <td>Tyson Dietrich</td>
+                    <td>Nick Duffield</td>
+                    <td>Andy Brink</td>
+                    <td>Josh Wyse</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
             <h3>All-Time Leaderboards</h3>
             <div id="league-history-content" class="mt-4 sheet-container">
               <div class="text-center">


### PR DESCRIPTION
## Summary
Added updates to the league history page, as well as a new emoji for the title of the website. Win number out of total wins is shown in parentheses for golfers with more than one major championship. Feedback is encouraged.

<img width="1231" height="701" alt="Screenshot 2025-07-22 at 1 29 36 PM" src="https://github.com/user-attachments/assets/95a96125-b195-490b-83f3-3cecfa036ab4" />
